### PR TITLE
Fix search functionality: filter calendar results and add 'No events …

### DIFF
--- a/app.js
+++ b/app.js
@@ -103,6 +103,7 @@
 
   // ---------- RENDER CALENDAR (ONLY CURRENT MONTH DAYS) ----------
   function render(){
+    let anyMatch = false;
     const y = viewDate.getFullYear();
     const m = viewDate.getMonth();
     els.monthLabel.textContent = viewDate.toLocaleString(undefined, { month:"long", year:"numeric" });
@@ -134,13 +135,41 @@
         els.grid.appendChild(cell);
         return;
       }
+      let noResultEl = document.getElementById("noResults");
+
+       if(!noResultEl){
+        noResultEl = document.createElement("div");
+        noResultEl.id = "noResults";
+        noResultEl.style.textAlign = "center";
+        noResultEl.style.padding = "10px";
+        noResultEl.style.fontWeight = "bold";
+        noResultEl.style.color = "red";
+        els.grid.parentNode.appendChild(noResultEl);
+    }
+
+      if(q && !anyMatch){
+        noResultEl.textContent = "No events found";
+        noResultEl.style.display = "block";
+      } else {
+        noResultEl.style.display = "none";
+     }
 
       const date = cellData.date;
       const key = toDateKey(date);
 
-      const dayEvents = getEventsByDate(key)
-        .filter(ev => !q || formatSearch(ev).includes(q))
-        .sort((a,b) => (a.start||"").localeCompare(b.start||""));
+      const allEvents = getEventsByDate(key);
+
+      const dayEvents = allEvents
+      .filter(ev => !q || formatSearch(ev).includes(q))
+      .sort((a,b) => (a.start||"").localeCompare(b.start||""));
+
+      if(dayEvents.length > 0){
+      anyMatch = true;
+      } 
+
+      if(q && dayEvents.length === 0){
+        cell.style.display = "none";
+      }
 
       cell.className = "cell";
       if(key === toDateKey(new Date())) cell.classList.add("today");


### PR DESCRIPTION
## 📌 Description
This PR fixes the search functionality in the calendar.

Previously, searching for an event did not properly filter the calendar and all dates were still visible. Also, no message was shown when no matching events were found.

This update improves the behavior by filtering results and providing user feedback.

---

## 🔗 Related Issue
Closes #5

---

## 🛠 Changes Made
- Fixed search logic to filter calendar dates based on query
- Hid non-matching dates during search
- Added "No events found" message when no matching events exist
- Improved overall user experience of search feature

---

## 📷 Screenshots (if applicable)
<img width="1368" height="768" alt="image" src="https://github.com/user-attachments/assets/b8400b7a-d303-4824-8b2e-3e2c2e5a6d67" />
<img width="1368" height="768" alt="image" src="https://github.com/user-attachments/assets/033ffeb7-e603-4565-8147-d96bced0f3e0" />


---

## ✅ Checklist
- [x] I have tested my changes
- [x] My code follows project guidelines
- [x] I have linked the related issue