### PR TITLE
feat: add export events as text file

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,11 +58,12 @@
 
       <div id="dayList" class="day-list"></div>
 
-      <!-- SIDE BUTTONS: Add/Edit/Delete -->
+      <!-- SIDE BUTTONS: Add/Edit/Delete/Export -->
       <div class="panel-foot">
         <button id="addBtn" class="btn primary" type="button">+ Add Event</button>
         <button id="editBtn" class="btn" type="button">Edit</button>
         <button id="deleteSideBtn" class="btn danger" type="button">Delete</button>
+        <button id="exportBtn" class="btn ghost" type="button">📥 Export</button>
       </div>
     </aside>
   </main>


### PR DESCRIPTION
## 📌 Description
Brief description of what this PR does.
Added an export button (📥 Export) to the Selected Day panel that allows users to download all their calendar events as a 
text file (my-calendar-events.txt). Events are sorted by date and include title, date, time, description, and reminder status.



## 🔗 Related Issue
Closes #18 


## 🛠 Changes Made
- Added 📥 Export button to the Selected Day panel in index.html
- Added exportEvents() function in app.js that:
  - Sorts all events by date
  - Formats each event with title, date, time, description, 
    and reminder status
  - Downloads events as a plain text file 
    (my-calendar-events.txt)
  - Shows a toast notification "Events exported!" on success
  - Shows a toast "No events to export!" if no events exist

## 📷 Screenshots (if applicable)
Before clicking Export Button:
<img width="1920" height="1080" alt="Screenshot (211)" src="https://github.com/user-attachments/assets/f7d6211b-a30d-45b8-92b5-bcc8cb665592" />
After clicking Export button:
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/70eb57fb-e31b-47c0-961a-6cd81d561530" />


## ✅ Checklist
- [x] I have tested my changes
- [x] My code follows project guidelines
- [x] I have linked the related issue
