### PR TITLE
feat: implement month dropdown in calendar header

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,7 +6,7 @@
     prevBtn: $("prevBtn"),
     nextBtn: $("nextBtn"),
     todayBtn: $("todayBtn"),
-    monthLabel: $("monthLabel"),
+    monthSelect: $("monthSelect"),
     yearSelect: $("yearSelect"),
 
     // calendar + side
@@ -63,6 +63,7 @@
   renderDayPanel();
   checkPopupReminders();
   initYearDropdown();
+  initMonthDropdown();
   }
   function initYearDropdown(){
   const currentYear = new Date().getFullYear();
@@ -81,6 +82,29 @@
   els.yearSelect.addEventListener("change", function(){
     const selectedYear = parseInt(this.value);
     viewDate = new Date(selectedYear, viewDate.getMonth(), 1);
+    render();
+  });
+}
+function initMonthDropdown(){
+  const months = [
+    "January","February","March","April","May","June",
+    "July","August","September","October","November","December"
+  ];
+
+  els.monthSelect.innerHTML = "";
+
+  months.forEach((month, index) => {
+    const option = document.createElement("option");
+    option.value = index;
+    option.textContent = month;
+    els.monthSelect.appendChild(option);
+  });
+
+  els.monthSelect.value = viewDate.getMonth();
+
+  els.monthSelect.addEventListener("change", function(){
+    const selectedMonth = parseInt(this.value);
+    viewDate = new Date(viewDate.getFullYear(), selectedMonth, 1);
     render();
   });
 }
@@ -133,7 +157,7 @@
     const y = viewDate.getFullYear();
     els.yearSelect.value = y;
     const m = viewDate.getMonth();
-    els.monthLabel.textContent = viewDate.toLocaleString(undefined, { month:"long", year:"numeric" });
+    els.monthSelect.value = m;
 
     const first = new Date(y, m, 1);
     const startDay = first.getDay(); // 0=Sun

--- a/index.html
+++ b/index.html
@@ -28,7 +28,20 @@
             <button id="prevBtn" class="btn" type="button" aria-label="Previous month">←</button>
             
            <div class="month-year-group">
-           <div id="monthLabel" class="month-label" aria-live="polite">—</div>
+           <select id="monthSelect" class="month-select" aria-label="Select month">
+  <option value="0">January</option>
+  <option value="1">February</option>
+  <option value="2">March</option>
+  <option value="3">April</option>
+  <option value="4">May</option>
+  <option value="5">June</option>
+  <option value="6">July</option>
+  <option value="7">August</option>
+  <option value="8">September</option>
+  <option value="9">October</option>
+  <option value="10">November</option>
+  <option value="11">December</option>
+</select>
            <select id="yearSelect" class="year-select" aria-label="Select year"></select>
            </div>
 

--- a/style.css
+++ b/style.css
@@ -362,6 +362,38 @@ h1{margin:0;font-size:16px; font-weight:700; letter-spacing:.2px; color:#514e6b;
 .year-select:focus {
   box-shadow: 0 0 0 4px var(--focus);
 }
+/* Month + Year Dropdown Styling */
+.month-select,
+.year-select {
+  padding: 10px 16px;
+  border-radius: 30px;
+  border: 1px solid rgba(255,255,255,0.7);
+  background: rgba(255,245,247,0.8);
+  backdrop-filter: blur(4px);
+  font-weight: 700;
+  color: #514e6b;
+  cursor: pointer;
+  outline: none;
+  box-shadow: 0 6px 12px rgba(185,164,255,0.15);
+  transition: all 0.25s ease;
+}
+
+/* Hover */
+.month-select:hover,
+.year-select:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 20px rgba(185,164,255,0.25);
+}
+
+/* Focus */
+.month-select:focus,
+.year-select:focus {
+  box-shadow: 0 0 0 4px var(--focus);
+}
+.month-select,
+.year-select {
+  background: linear-gradient(145deg, #fff5f7, #ffeef5);
+}
 /* ---------- DAYS OF WEEK ---------- */
 
 .dow{
@@ -720,6 +752,13 @@ body.dark .weekdays div {
   background: #eaecf0;
   color: #1e293b;
   font-weight: 600;
+}
+body.dark .month-select,
+body.dark .year-select {
+  background: #334155;
+  color: #f1f5f9;
+  border: 1px solid #475569;
+  box-shadow: none;
 }
 
 body.dark .cell .date span:first-child {


### PR DESCRIPTION
## 📌 Description
This PR adds a month dropdown selector to the calendar header, allowing users to directly jump to any month instead of navigating month-by-month using arrow buttons.

This improves usability and makes navigation faster and more intuitive.

---

## 🔗 Related Issue
Closes #23 




---

## 🛠 Changes Made
- Added month `<select>` dropdown in calendar header
- Connected dropdown to calendar render logic
- Synced month selection with year selector
- Styled dropdown to match existing UI theme
- Added dark mode support for dropdown

---

## 📷 Screenshots (if applicable)
Updated calendar header with month dropdown selector.
<img width="1009" height="872" alt="Screenshot 2026-02-23 181331" src="https://github.com/user-attachments/assets/8bae08f3-afaf-4529-b0be-2a2b7f87033a" />

---

## ✅ Checklist
- [x] I have tested my changes
- [x] My code follows project guidelines
- [x] I have linked the related issue